### PR TITLE
Accept InputStream for Spring Boot support

### DIFF
--- a/src/main/java/com/melloware/jintellitype/JIntellitype.java
+++ b/src/main/java/com/melloware/jintellitype/JIntellitype.java
@@ -399,6 +399,15 @@ public final class JIntellitype implements JIntellitypeConstants {
    public static void setLibraryLocation(File libraryFile) {
       JIntellitype.libraryLocation = libraryFile.getAbsolutePath();
    }
+   
+   /**
+    * Sets the libraryInputStream of the DLL using InputStream
+    * <p>
+    * @param libraryInputStream the java.io.InputStream representing the DLL
+    */
+   public static void setLibraryInputStream(InputStream libraryInputStream) {
+      JIntellitype.libraryInputStream = libraryInputStream;
+   }
 
    /**
     * Notifies all listeners that Hotkey was pressed.

--- a/src/main/java/com/melloware/jintellitype/JIntellitype.java
+++ b/src/main/java/com/melloware/jintellitype/JIntellitype.java
@@ -60,6 +60,11 @@ public final class JIntellitype implements JIntellitypeConstants {
     * Static variable to hold the libary location if set
     */
    private static String libraryLocation = null;
+   
+   /**
+    * Static variable to hold InputStream for the library
+    */
+   private static InputStream libraryInputStream = null;
 
    /**
     * Listeners collection for Hotkey events
@@ -128,7 +133,7 @@ public final class JIntellitype implements JIntellitypeConstants {
     * @throws IOException if any IO error occurs
     */
    private void fromJarToFs(String jarPath, String filePath) throws IOException {
-      InputStream is = null;
+      InputStream is = libraryInputStream;
       OutputStream os = null;
       try {
          File file = new File(filePath);
@@ -139,7 +144,8 @@ public final class JIntellitype implements JIntellitypeConstants {
             }
          }
 
-         is = ClassLoader.getSystemClassLoader().getResourceAsStream(jarPath);
+         if (is == null)
+            is = ClassLoader.getSystemClassLoader().getResourceAsStream(jarPath);
          os = new FileOutputStream(filePath);
          byte[] buffer = new byte[8192];
          int bytesRead;


### PR DESCRIPTION
Allow to directly specify InputStream of the library to support Spring Boot resource loading mechanism for JAR files.